### PR TITLE
fixes history propType bug

### DIFF
--- a/client/src/components/dataView.js
+++ b/client/src/components/dataView.js
@@ -12,7 +12,7 @@ export default class View extends Component {
       moments: props.location.state.moments,
       moment: 1,
       summary: props.location.state.summary, // eslint-disable-line
-      history: props.location.state.history  // eslint-disable-line
+      emoHistory: props.location.state.emoHistory  // eslint-disable-line
     };
   }
 
@@ -21,7 +21,7 @@ export default class View extends Component {
       <div>
         <CancelButton />
         <HamburgerMenu userId={this.props.location.state.userId} />
-        <TreeView history={this.state.history} backgroundColor={'black'} />
+        <TreeView emoHistory={this.state.emoHistory} backgroundColor={'black'} />
       </div>
     );
   }
@@ -29,7 +29,7 @@ export default class View extends Component {
 
 View.propTypes = {
 
-  history: PropTypes.arrayOf(PropTypes.shape({
+  emoHistory: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number,
     _id: PropTypes.string,
     summary: PropTypes.shape({

--- a/client/src/components/dataViewMenu.js
+++ b/client/src/components/dataViewMenu.js
@@ -9,7 +9,7 @@ import OffTheWallIcon from 'material-ui/svg-icons/image/details';
 
 /* eslint-disable react/prop-types */
 const DataMenu = ({
-  moments, summary, history, userId, dataAnchor, toggleData, dataOpen, ...muiProps
+  moments, summary, emoHistory, userId, dataAnchor, toggleData, dataOpen, ...muiProps
 }) => {
 /* eslint-enable react/prop-types */
   const handleTouchTap = (e) => {
@@ -37,7 +37,7 @@ const DataMenu = ({
               state: {
                 moments,
                 summary,
-                history,
+                emoHistory,
                 userId }
             }}
             >

--- a/client/src/components/treeView.js
+++ b/client/src/components/treeView.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Line, Point } from '../lib';
 import sampleData from '../lib/sampleHistory.json';
 
-const TreeView = ({ history, backgroundColor }) => {
+const TreeView = ({ emoHistory, backgroundColor }) => {
   const MAXHIST = 2000; // Stops exponential growth of the tree
 
   const draw = (c) => {
@@ -13,18 +13,18 @@ const TreeView = ({ history, backgroundColor }) => {
     const lines = [];
     const ctx = c.getContext('2d');
 
+    const history = emoHistory.length ?
+      Object.assign([], emoHistory) : Object.assign([], sampleData);
+
     const height = Math.max((1 / (90 * history.length)), 1 / MAXHIST);
     const maxIterations = // leaf count 2^n-1;
       Math.max(Math.ceil(Math.log(history.length) / Math.log(2)) + 1, 3);
     const startSize = 10 + Math.ceil(Math.log(history.length)); // trunk size
 
-    const newHistory = history.length ?
-      Object.assign([], history) : Object.assign([], sampleData);
-
     const opts = {
       speed: 1,
       rotate: true,
-      history: newHistory,
+      history,
       splitSizeProbabilityMultiplier: height,
       maxIterations,
       startSize,
@@ -87,7 +87,7 @@ const TreeView = ({ history, backgroundColor }) => {
 
 TreeView.propTypes = {
   backgroundColor: PropTypes.string,
-  history: PropTypes.arrayOf(PropTypes.shape({
+  emoHistory: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.number,
     _id: PropTypes.string,
     summary: PropTypes.shape({

--- a/client/src/components/view.js
+++ b/client/src/components/view.js
@@ -17,7 +17,7 @@ export default class View extends Component {
       moments: [],
       filteredMoments: null,
       summary: [0, 0, 0, 0, 0],
-      history: [],
+      emoHistory: [],
       dataOpen: false,
       toggleData: this.toggleData
     };
@@ -32,10 +32,10 @@ export default class View extends Component {
         this.state.moments.length ?
           Object.keys(res.data.aggregate.summary)
             .map(emotion => res.data.aggregate.summary[emotion]) : [1, 1, 1, 1, 1];
-      const history = res.data.aggregate.history;
+      const emoHistory = res.data.aggregate.history;
       this.setState({
         summary,
-        history
+        emoHistory
       });
     })
     .catch(err => console.log(err)); // eslint-disable-line no-console


### PR DESCRIPTION
There was a namespace collision between the prop 'history' and the history object in React Router. This fixes that bug.