### PR TITLE
fixes tree rendering when there is no moment history

### DIFF
--- a/client/src/components/treeView.js
+++ b/client/src/components/treeView.js
@@ -16,7 +16,8 @@ const TreeView = ({ emoHistory, backgroundColor }) => {
     const history = emoHistory.length ?
       Object.assign([], emoHistory) : Object.assign([], sampleData);
 
-    const height = Math.max((1 / (90 * history.length)), 1 / MAXHIST);
+    const height =
+      !emoHistory.length ? 1 : Math.max((1 / (90 * history.length)), 1 / MAXHIST);
     const maxIterations = // leaf count 2^n-1;
       Math.max(Math.ceil(Math.log(history.length) / Math.log(2)) + 1, 3);
     const startSize = 10 + Math.ceil(Math.log(history.length)); // trunk size


### PR DESCRIPTION
For some reason, the tree was rendering as a sprout when there was no emotional history. This fixes that bug.