### PR TITLE
changes landing page to login and fixes tree bug

### DIFF
--- a/client/src/components/treeView.js
+++ b/client/src/components/treeView.js
@@ -16,7 +16,8 @@ const TreeView = ({ emoHistory, backgroundColor }) => {
     const history = emoHistory.length ?
       Object.assign([], emoHistory) : Object.assign([], sampleData);
 
-    const height = Math.max((1 / (90 * history.length)), 1 / MAXHIST);
+    const height =
+      !emoHistory.length ? 1 : Math.max((1 / (90 * history.length)), 1 / MAXHIST);
     const maxIterations = // leaf count 2^n-1;
       Math.max(Math.ceil(Math.log(history.length) / Math.log(2)) + 1, 3);
     const startSize = 10 + Math.ceil(Math.log(history.length)); // trunk size

--- a/server/app.js
+++ b/server/app.js
@@ -19,9 +19,10 @@ app.use(middleware.passport.initialize());
 app.use(middleware.passport.session());
 app.use(middleware.flash());
 
+app.use('/', routes.auth);
+
 app.use(express.static(path.join(__dirname, '../public')));
 
-app.use('/', routes.auth);
 app.use('/api', routes.api);
 app.use('/api/profiles', routes.profiles);
 app.use((req, res) => res.render('index.ejs'));


### PR DESCRIPTION
This sets the landing page to be login.ejs and fixes a bug which caused the tree to render as a sprout when there was no emotional history to render.